### PR TITLE
feat: add optional owner param to syncer methods

### DIFF
--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -328,24 +328,24 @@ export class SDK {
     return await this.sessionSDK.deleteSession(session)
   }
 
-  public async getSyncers() {
-    return await this.syncerSDK.getSyncers()
+  public async getSyncers(owner?: string) {
+    return await this.syncerSDK.getSyncers(owner)
   }
 
   public async getSyncer(id: string) {
     return await this.syncerSDK.getSyncer(id)
   }
 
-  public async addSyncer(syncer: Syncer) {
-    return await this.syncerSDK.addSyncer(syncer)
+  public async addSyncer(syncer: Syncer, owner?: string) {
+    return await this.syncerSDK.addSyncer(syncer, owner)
   }
 
-  public async updateSyncer(syncer: Syncer) {
-    return await this.syncerSDK.updateSyncer(syncer)
+  public async updateSyncer(syncer: Syncer, owner?: string) {
+    return await this.syncerSDK.updateSyncer(syncer, owner)
   }
 
-  public async deleteSyncer(syncer: Syncer) {
-    return await this.syncerSDK.deleteSyncer(syncer)
+  public async deleteSyncer(syncer: Syncer, owner?: string) {
+    return await this.syncerSDK.deleteSyncer(syncer, owner)
   }
 
   public async getPermissions() {

--- a/src/syncer.ts
+++ b/src/syncer.ts
@@ -61,14 +61,14 @@ export class SyncerSDK {
     this.request = request
   }
 
-  public async getSyncers() {
+  public async getSyncers(owner = this.config.orgName) {
     if (!this.request) {
       throw new Error('request init failed')
     }
 
     return (await this.request.get('/get-syncers', {
       params: {
-        owner: this.config.orgName,
+        owner,
       },
     })) as unknown as Promise<AxiosResponse<{ data: Syncer[] }>>
   }
@@ -85,13 +85,17 @@ export class SyncerSDK {
     })) as unknown as Promise<AxiosResponse<{ data: Syncer }>>
   }
 
-  public async modifySyncer(method: string, syncer: Syncer) {
+  public async modifySyncer(
+    method: string,
+    syncer: Syncer,
+    owner = this.config.orgName,
+  ) {
     if (!this.request) {
       throw new Error('request init failed')
     }
 
     const url = `/${method}`
-    syncer.owner = this.config.orgName
+    syncer.owner = owner
     return (await this.request.post(url, syncer, {
       params: {
         id: `${syncer.owner}/${syncer.name}`,
@@ -99,15 +103,15 @@ export class SyncerSDK {
     })) as unknown as Promise<AxiosResponse<Record<string, unknown>>>
   }
 
-  public async addSyncer(syncer: Syncer) {
-    return this.modifySyncer('add-syncer', syncer)
+  public async addSyncer(syncer: Syncer, owner?: string) {
+    return this.modifySyncer('add-syncer', syncer, owner)
   }
 
-  public async updateSyncer(syncer: Syncer) {
-    return this.modifySyncer('update-syncer', syncer)
+  public async updateSyncer(syncer: Syncer, owner?: string) {
+    return this.modifySyncer('update-syncer', syncer, owner)
   }
 
-  public async deleteSyncer(syncer: Syncer) {
-    return this.modifySyncer('delete-syncer', syncer)
+  public async deleteSyncer(syncer: Syncer, owner?: string) {
+    return this.modifySyncer('delete-syncer', syncer, owner)
   }
 }

--- a/test/syncer.test.ts
+++ b/test/syncer.test.ts
@@ -54,7 +54,7 @@ test('TestSyncer', async () => {
   // Get all objects and check if our added object is in the list
   const {
     data: { data: syncers },
-  } = await sdk.getSyncers()
+  } = await sdk.getSyncers(syncer.owner)
   const found = syncers.some((item) => item.name === name)
   if (!found) {
     throw new Error('Added object not found in list')
@@ -68,6 +68,14 @@ test('TestSyncer', async () => {
     throw new Error(
       `Retrieved object does not match added object: ${retrievedSyncer.name} != ${name}`,
     )
+  }
+
+  // Get the objects
+  const {
+    data: { data: retrievedSyncers },
+  } = await sdk.getSyncers(syncer.owner)
+  if (retrievedSyncers.length !== 1 || retrievedSyncers[0].name !== name) {
+    throw new Error('Failed to get objects')
   }
 
   // Update the object


### PR DESCRIPTION
Previous implementation always used `this.orgName` for the required `owner` field, however the expected owner [can be a user name, and not an org name](https://github.com/casdoor/casdoor/blob/master/object/syncer.go#L71).
For example, the Casdoor web app [always sets the `owner` to "admin"](https://github.com/casdoor/casdoor/blob/master/web/src/SyncerListPage.js#L30).
This in turns make it impossible to retrieve syncers created through the web app using the SDK.

This addition fixes this issue by adding an optional owner parameter to the syncer methods.