### PR TITLE
feat: add optional AxiosRequestConfig parameter in constructor, add /introspect endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ Initialization requires 5 parameters, which are all string type:
 
 ```typescript
 import { SDK, Config } from 'casdoor-nodejs-sdk'
+import type { AxiosRequestConfig } from 'axios';
+import https from 'node:https';
+
+// Optional param for providing a self-signed CA with requests.
+const axiosConfig: AxiosRequestConfig = {
+  httpsAgent: new https.Agent({ ca: ... })
+}
 
 const authCfg: Config = {
   endpoint: '',
@@ -58,6 +65,8 @@ const authCfg: Config = {
 }
 
 const sdk = new SDK(authCfg)
+// or
+const sdk = new SDK(authCfg, axiosConfig)
 
 // call sdk to handle
 ```

--- a/src/request.ts
+++ b/src/request.ts
@@ -23,6 +23,7 @@ export default class Request {
       baseURL: config.url,
       timeout: config.timeout || 60000,
       headers: config.headers,
+      ...config,
     })
   }
   get(url: string, config?: AxiosRequestConfig<any>) {

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -528,6 +528,10 @@ export class SDK {
     return await this.tokenSDK.deleteToken(token)
   }
 
+  public async introspect(token: string, token_type_hint: string) {
+    return await this.tokenSDK.introspect(token, token_type_hint)
+  }
+
   public async getWebhooks() {
     return await this.webhookSDK.getWebhooks()
   }

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -40,6 +40,7 @@ import { Sms, SmsSDK } from './sms'
 import { MfaData, MfaSDK } from './mfa'
 import { CasbinRequest, EnforceSDK } from './enforce'
 import { UrlSDK } from './url'
+import type { AxiosRequestConfig } from 'axios'
 
 export class SDK {
   private readonly config: Config
@@ -71,7 +72,7 @@ export class SDK {
   private enforceSDK: EnforceSDK
   private urlSDK: UrlSDK
 
-  constructor(config: Config) {
+  constructor(config: Config, axiosConfig?: AxiosRequestConfig) {
     this.config = config
     this.request = new Request({
       url: config.endpoint + '/api',
@@ -83,6 +84,7 @@ export class SDK {
             `${this.config.clientId}:${this.config.clientSecret}`,
           ).toString('base64'),
       },
+      ...axiosConfig,
     })
     this.userSDK = new UserSDK(this.config, this.request)
     this.adapterSDK = new AdapterSDK(this.config, this.request)

--- a/src/token.ts
+++ b/src/token.ts
@@ -96,4 +96,17 @@ export class TokenSDK {
   public async deleteToken(token: Token) {
     return this.modifyToken('delete-token', token)
   }
+
+  public async introspect(token: string, token_type_hint: string) {
+    if (!this.request) {
+      throw new Error('request init failed')
+    }
+
+    return (await this.request.post('/login/oauth/introspect', {
+      params: {
+        token,
+        token_type_hint,
+      },
+    })) as unknown as Promise<AxiosResponse<Record<string, unknown>>>
+  }
 }

--- a/src/token.ts
+++ b/src/token.ts
@@ -102,11 +102,17 @@ export class TokenSDK {
       throw new Error('request init failed')
     }
 
-    return (await this.request.post('/login/oauth/introspect', {
-      params: {
+    return (await this.request.post(
+      '/login/oauth/introspect',
+      {
         token,
         token_type_hint,
       },
-    })) as unknown as Promise<AxiosResponse<Record<string, unknown>>>
+      {
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+      },
+    )) as unknown as Promise<AxiosResponse<Record<string, unknown>>>
   }
 }


### PR DESCRIPTION
I ran into issues with this library's use of Axios and the intranet self-signed enterprise certificate on the Casdoor instance. Calls to `SDK.getAuthToken(code)` would be met with:

```
Error: self-signed certificate in certificate chain
    at AxiosError.from (/projectroot/node_modules/.pnpm/axios@1.6.7/node_modules/axios/dist/node/axios.cjs:837:14)
```
A solution is to provide an instance of `https.Agent({ ca: string })` with the AxiosRequestConfig when creating the Axios instance. This wasn't possible as there was no exposed method to add a custom AxiosRequestConfig with creating a new SDK() instance.
I added an optional param `axiosConfig?: AxiosRequestConfig` to the `SDK` construction which is passed with `new Request(...)`.