### PR TITLE
feat: remove extra '}' typo in get profile URL APIs

### DIFF
--- a/src/url.ts
+++ b/src/url.ts
@@ -45,13 +45,13 @@ export class UrlSDK {
     return this.getSignUrl('login', redirectUri)
   }
 
-  public getUserProfileUrl(userName: string, accessToken: string): string {
-    const param = accessToken ? `?access_token=${accessToken}}` : ''
+  public getUserProfileUrl(userName: string, accessToken?: string): string {
+    const param = accessToken ? `?access_token=${accessToken}` : ''
     return `${this.config.endpoint}/users/${this.config.orgName}/${userName}${param}`
   }
 
-  public getMyProfileUrl(accessToken: string): string {
-    const param = accessToken ? `?access_token=${accessToken}}` : ''
+  public getMyProfileUrl(accessToken?: string): string {
+    const param = accessToken ? `?access_token=${accessToken}` : ''
     return `${this.config.endpoint}/account${param}`
   }
 }


### PR DESCRIPTION
* Remove `}` typo in generated user profile urls
* Make accessToken explicitly optional, reflecting the actual runtime behavior (typings only, no runtime changes).