### PR TITLE
style: Modify access modifiers for config and request

### DIFF
--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -43,8 +43,8 @@ import { UrlSDK } from './url'
 import type { AxiosRequestConfig } from 'axios'
 
 export class SDK {
-  private readonly config: Config
-  private readonly request: Request
+  protected readonly config: Config
+  protected readonly request: Request
   private userSDK: UserSDK
   private adapterSDK: AdapterSDK
   private applicationSDK: ApplicationSDK


### PR DESCRIPTION
I encountered the same issue as #55, and I hope to extend the functionality of the SDK through the internal request method.

example:
```ts
import { SDK } from 'casdoor-nodejs-sdk';

export class Casdoor extends SDK {

  public async getAuthTokenByPassword(username: string, password: string) {
    if (!request) {
      throw new Error('request init failed')
    }

    const {
      data: { access_token, refresh_token },
    } = (await this.request.post('login/oauth/access_token', {
      client_id: this.config.clientId,
      client_secret: this.config.clientSecret,
      grant_type: 'password',
      username,
      password,
    })) as unknown as AxiosResponse<{
      access_token: string
      refresh_token: string
    }>

    return {
      access_token,
      refresh_token,
    }

  }

}

```