### PR TITLE
feat: add enforcerId parameter to enforce and batchEnforce methods in SDK

### DIFF
--- a/src/enforce.ts
+++ b/src/enforce.ts
@@ -32,6 +32,7 @@ export class EnforceSDK {
     permissionId: string,
     modelId: string,
     resourceId: string,
+    enforcerId: string,
     casbinRequest: CasbinRequest,
   ): Promise<boolean> {
     const response = await this.doEnforce<CasbinResponse>(
@@ -39,6 +40,7 @@ export class EnforceSDK {
       permissionId,
       modelId,
       resourceId,
+      enforcerId,
       casbinRequest,
     )
     const { data } = response.data
@@ -54,6 +56,7 @@ export class EnforceSDK {
     permissionId: string,
     modelId: string,
     resourceId: string,
+    enforcerId: string,
     casbinRequest: CasbinRequest[],
   ): Promise<boolean[]> {
     const response = await this.doEnforce<CasbinResponse[]>(
@@ -61,6 +64,7 @@ export class EnforceSDK {
       permissionId,
       modelId,
       resourceId,
+      enforcerId,
       casbinRequest,
     )
     const { data } = response.data
@@ -72,6 +76,7 @@ export class EnforceSDK {
     permissionId: string,
     modelId: string,
     resourceId: string,
+    enforcerId: string,
     casbinRequest: CasbinRequest | CasbinRequest[],
   ) {
     if (!this.request) {
@@ -84,6 +89,7 @@ export class EnforceSDK {
         permissionId: permissionId,
         modelId: modelId,
         resourceId: resourceId,
+        enforcerId: enforcerId,
       },
     })) as unknown as Promise<
       AxiosResponse<{

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -631,12 +631,14 @@ export class SDK {
     permissionId: string,
     modelId: string,
     resourceId: string,
+    enforcerId: string,
     casbinRequest: CasbinRequest,
   ) {
     return await this.enforceSDK.enforce(
       permissionId,
       modelId,
       resourceId,
+      enforcerId,
       casbinRequest,
     )
   }
@@ -645,12 +647,14 @@ export class SDK {
     permissionId: string,
     modelId: string,
     resourceId: string,
+    enforcerId: string,
     casbinRequest: CasbinRequest[],
   ) {
     return await this.enforceSDK.batchEnforce(
       permissionId,
       modelId,
       resourceId,
+      enforcerId,
       casbinRequest,
     )
   }


### PR DESCRIPTION
This pull request updates the enforcement methods in both the `EnforceSDK` and `SDK` classes to support a new `enforcerId` parameter. This change ensures that all enforcement requests can specify which enforcer instance should be used, improving flexibility and control over authorization logic.

**API changes to enforcement methods:**

* Added an `enforcerId` parameter to the `enforce` and `batchEnforce` methods in the `EnforceSDK` class, and ensured this parameter is included in the payload sent to the backend. [[1]](diffhunk://#diff-88931042e3e9f6d0701744fa8a350c11e43c54a28e5218c3b9d0de9b23063efbR35-R43) [[2]](diffhunk://#diff-88931042e3e9f6d0701744fa8a350c11e43c54a28e5218c3b9d0de9b23063efbR59-R67) [[3]](diffhunk://#diff-88931042e3e9f6d0701744fa8a350c11e43c54a28e5218c3b9d0de9b23063efbR79) [[4]](diffhunk://#diff-88931042e3e9f6d0701744fa8a350c11e43c54a28e5218c3b9d0de9b23063efbR92)
* Updated the `enforce` and `batchEnforce` methods in the `SDK` class to accept and forward the new `enforcerId` parameter to the underlying `EnforceSDK` methods. [[1]](diffhunk://#diff-1cb309fed92276bb9dea70cd8a7de337eb3c71e02ac30214c026d797dfe44aceR634-R641) [[2]](diffhunk://#diff-1cb309fed92276bb9dea70cd8a7de337eb3c71e02ac30214c026d797dfe44aceR650-R657)